### PR TITLE
Decompress: single ZLibStream.Read under-fills large compressed records

### DIFF
--- a/DatReaderWriter/DatDatabase.cs
+++ b/DatReaderWriter/DatDatabase.cs
@@ -1055,7 +1055,16 @@ namespace DatReaderWriter {
 #if (NET8_0_OR_GREATER)
             using var outputStream = new System.IO.MemoryStream(data.Slice(4).ToArray());
             using var zlibStream = new ZLibStream(outputStream, CompressionMode.Decompress);
-            return zlibStream.Read(destination);
+            // Stream.Read may return fewer bytes than requested; loop until the
+            // stream is drained or the destination is full, or large records
+            // come back truncated.
+            var totalRead = 0;
+            int read;
+            while (totalRead < destination.Length &&
+                   (read = zlibStream.Read(destination.Slice(totalRead))) > 0) {
+                totalRead += read;
+            }
+            return totalRead;
 #else
             var zlib = new ZLibDotNet.ZLib();
             var dataArray = data.ToArray(); 


### PR DESCRIPTION
On .NET 8+, `DatDatabase.Decompress(ReadOnlySpan<byte>, Span<byte>)` does a single

```csharp
return zlibStream.Read(destination);
```

`Stream.Read` is not guaranteed to fill the destination — it may return any positive number of bytes — and `ZLibStream` routinely returns short reads for records larger than its internal buffer. Result: any sufficiently large compressed record comes back **silently truncated** through `TryGetFileBytes` / `TryGetFileBytesAsync` / `TryGetRawFileBytes` (the `byte[]` overload delegates to the span overload, so both are affected). The buffer has the right length (allocated from the BTEntry size) but only the head is inflated; the tail is zeros.

The retail client is unaffected (zlib `uncompress` fills fully) — this is a DRW-reader-only bug, but it means DRW cannot round-trip records that its own `TryWriteCompressedBytes` produced.

Repro: write any record whose uncompressed size is a few hundred KiB (e.g. a 2048² DXT5 RenderSurface) with `TryWriteCompressedBytes`, re-open the dat, `TryGetFileBytes` → truncated payload.

Fix: loop until the stream drains or the destination is full. The pre-net8 `ZLibDotNet.Uncompress` branch already fills fully and is untouched.

Found while building tooling that compresses texture records; verified against a full portal.dat (20k+ compressed records) by comparing a manual full-read inflate of the stored bytes against what DRW returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
